### PR TITLE
Better escape: make timeout shorter

### DIFF
--- a/lua/plugins/better-escape.lua
+++ b/lua/plugins/better-escape.lua
@@ -1,7 +1,7 @@
 return {
   "max397574/better-escape.nvim",
   opts = {
-    timeout = vim.o.timeoutlen, -- after `timeout` passes, you can press the escape key and the plugin will ignore it
+    timeout = 100, -- after `timeout` passes, you can press the escape key and the plugin will ignore it
     default_mappings = true, -- setting this to false removes all the default mappings
   },
 }


### PR DESCRIPTION
Rationale: sometimes pressing `k` after `j` in visual mode cancels selection unintentionally.